### PR TITLE
Added scale functionality to match NinePatch

### DIFF
--- a/tenpatch/src/com/ray3k/tenpatch/TenPatchDrawable.java
+++ b/tenpatch/src/com/ray3k/tenpatch/TenPatchDrawable.java
@@ -849,8 +849,8 @@ public class TenPatchDrawable extends TextureRegionDrawable {
      * @see NinePatch#scale(float, float)
      */
     public void scale(float scaleX, float scaleY) {
-        scaleX *= scaleX;
-        scaleY *= scaleY;
+        this.scaleX *= scaleX;
+        this.scaleY *= scaleY;
     }
 
     /**


### PR DESCRIPTION
While TenPatch is full of functionalities, there is no way to currently render the TenPatch at a different scale than 1 pixel to 1 world unit. This makes is inconvenient to use in situations where you don't have a viewport that directly matches pixel sizes. This simple PR adds the scaling functionality in a way similar to how NinePatch does it.

Similar to the way NinePatch's scale function works, scaling does not affect the size of the resulting TenPatch but only affects the resolution at which the regions within the TenPatch are drawn.